### PR TITLE
Fix module path for Shopify import

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -13,7 +13,7 @@ from fastapi.middleware.cors import CORSMiddleware
 import httpx
 import redis.asyncio as redis
 from fastapi.responses import PlainTextResponse
-from shopify_integration import router as shopify_router
+from .shopify_integration import router as shopify_router
 from dotenv import load_dotenv
 import asyncio, subprocess, os
 from pathlib import Path


### PR DESCRIPTION
## Summary
- fix relative import for Shopify router

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687fef05c2088321a6ef208233f65deb