### PR TITLE
Clarify required Shopify variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ Supported variable sets:
    - `IRRAKIDS_STORE_DOMAIN`
    - `IRRANOVA_STORE_DOMAIN`
 
-Each set requires an API key, password, and store URL (or domain). Only one set needs to be defined.
+Each set requires an API key, password, and store URL (or domain). Only one set
+needs to be defined. You **must** provide one complete set of `SHOPIFY_*`,
+`IRRAKIDS_*`, or `IRRANOVA_*` variables before starting the backend or it will
+exit with the error `Missing Shopify environment variables`.
 
 ## Example: Setting variables on Cloud Run
 


### PR DESCRIPTION
## Summary
- highlight that one full set of `SHOPIFY_*`, `IRRAKIDS_*`, or `IRRANOVA_*` variables is required
- mention the startup failure message `Missing Shopify environment variables`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688025a8475083218cd40f86ad2b2ca0