### PR TITLE
Fix backend requirements encoding

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-﻿annotated-types==0.7.0
+annotated-types==0.7.0
 anyio==4.9.0
 beautifulsoup4==4.13.3
 cachetools==5.5.2


### PR DESCRIPTION
## Summary
- convert backend requirements to plain UTF-8 so pip can read them
- ensure dependency list includes python-multipart, aiosqlite, aiofiles and redis

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement annotated-types==0.7.0)*

------
https://chatgpt.com/codex/tasks/task_e_6880c16c85d88321944c0f29bfd87897