### PR TITLE
Fix DB init path creation

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -341,6 +341,8 @@ class DatabaseManager:
 
     def __init__(self, db_path: str | None = None):
         self.db_path = db_path or DB_PATH
+        # Ensure parent directory exists before attempting to connect
+        Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
 
     # ── basic connection helper ──
     @asynccontextmanager


### PR DESCRIPTION
## Summary
- ensure DatabaseManager creates the parent directory of the DB path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6880c5770c5c8321a31d6c7b5e736a5b