### PR TITLE
Serve React frontend in FastAPI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM python:3.12-slim
 
 WORKDIR /app
 COPY . .
+# Ensure the built frontend is included
+COPY frontend/build ./frontend/build
 RUN pip install --no-cache-dir -r backend/requirements.txt
 
 ENV PYTHONDONTWRITEBYTECODE=1 \

--- a/README.md
+++ b/README.md
@@ -39,3 +39,15 @@ gcloud run deploy whatsapp-backend \
 
 Replace the values with the credentials for your Shopify store. Alternatively use the `IRRAKIDS_*` or `IRRANOVA_*` variable names if those are available.
 
+## Frontend build
+
+Before running the backend make sure the React frontend is compiled:
+
+```bash
+cd frontend
+npm install
+npm run build
+```
+
+The FastAPI service serves the static files from the built directory at the root path (`/`).
+

--- a/backend/main.py
+++ b/backend/main.py
@@ -835,6 +835,9 @@ messenger = message_processor.whatsapp_messenger
 app = FastAPI()
 app.include_router(shopify_router)
 
+# Serve React build before other routes so '/' returns index.html
+app.mount("/", StaticFiles(directory="frontend/build", html=True), name="frontend")
+
 # Mount the media directory to serve uploaded files
 app.mount("/media", StaticFiles(directory="media"), name="media")
 
@@ -1225,7 +1228,6 @@ async def get_all_catalog_products():
         return []
 
 # Add static file serving for media files
-from fastapi.staticfiles import StaticFiles
 
 
 # 1. Fix the port in main block


### PR DESCRIPTION
## Summary
- mount built React static files in backend
- copy `frontend/build` in Dockerfile
- document how to build the React frontend

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880dd40b3bc832193e298f08102b6da