### PR TITLE
Update Docker build docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,7 @@ npm run build
 
 The FastAPI service serves the static files from the built directory at the root path (`/`).
 
+## Building the Docker image
+
+Before invoking `docker build`, make sure the React frontend has been compiled by running `npm run build` inside the `frontend` directory. The Dockerfile uses `COPY frontend/build ./frontend/build` to include the built assets in the image, so the build step must complete successfully first.
+


### PR DESCRIPTION
## Summary
- document that `npm run build` is required before running `docker build`
- clarify the use of `COPY frontend/build` in Dockerfile

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6880e33d035883218ba66e7cc90840d0