### PR TITLE
Fix _get_file_extension scope

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -795,7 +795,7 @@ class MessageProcessor:
             print(f"Error downloading media {media_id}: {e}")
             return ""
     
-def _get_file_extension(self, media_type: str) -> str:
+    def _get_file_extension(self, media_type: str) -> str:
         """Get file extension based on media type"""
         extensions = {
             "image": ".jpg",


### PR DESCRIPTION
## Summary
- move `_get_file_extension()` inside `MessageProcessor`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6880ee3418bc8321a02cf2a18dd13534