### PR TITLE
Remove unused root package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ npm install
 npm run build
 ```
 
+All Node dependencies are defined in `frontend/package.json`.
+
 When building the Docker image this step is handled automatically.
 
 The FastAPI service serves the static files from the built directory at the root path (`/`).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,0 @@
-{
-  "dependencies": {
-    "dayjs": "^1.11.13",
-    "emoji-picker-react": "^4.12.2",
-    "openai": "^4.95.1"
-  }
-}


### PR DESCRIPTION
## Summary
- delete unused root-level `package.json`
- clarify that all Node dependencies live in `frontend/package.json`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6880f6c8d9788321bd226d377d9a4380