### PR TITLE
Add OpenAI dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -22,6 +22,7 @@ httpx==0.28.1
 idna==3.10
 oauth2client==4.1.3
 oauthlib==3.2.2
+openai
 pillow==11.1.0
 proto-plus==1.26.1
 protobuf==6.30.2


### PR DESCRIPTION
## Summary
- include `openai` in backend dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6881204ff1508321bc14b1d384f88a92