### PR TITLE
Refactor API endpoints to use environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,25 @@ All Node dependencies are defined in `frontend/package.json`.
 
 When building the Docker image this step is handled automatically.
 
+
 The FastAPI service serves the static files from the built directory at the root path (`/`).
+
+### API and WebSocket URLs
+
+The React build reads two optional variables:
+
+* `REACT_APP_API_BASE` - base URL for all HTTP requests
+* `REACT_APP_WS_URL` - WebSocket endpoint prefix
+
+If these variables are not set, the frontend will default to relative paths and the current host.
+
+Example build command:
+
+```bash
+REACT_APP_API_BASE=https://api.example.com \
+REACT_APP_WS_URL=wss://api.example.com/ws/ \
+npm run build
+```
 
 ## Building the Docker image
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,7 +6,8 @@ import ShopifyIntegrationsPanel from './ShopifyIntegrationsPanel';
 import axios from 'axios';
 
 // Read API base from env for production/dev compatibility
-const API_BASE = process.env.REACT_APP_API_BASE || "http://localhost:5000";
+// Default to relative paths if not provided
+const API_BASE = process.env.REACT_APP_API_BASE || "";
 
 export default function App() {
   const [products, setProducts] = useState([]);
@@ -73,9 +74,10 @@ export default function App() {
     if (wsRef.current) wsRef.current.close();
 
     // Connect to backend WebSocket for the selected user
-    const ws = new WebSocket(
-      (process.env.REACT_APP_WS_URL || "ws://localhost:5000/ws/") + activeUser.user_id
-    );
+    const wsBase =
+      process.env.REACT_APP_WS_URL ||
+      `${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${window.location.host}/ws/`;
+    const ws = new WebSocket(`${wsBase}${activeUser.user_id}`);
     wsRef.current = ws;
 
     ws.onopen = () => {

--- a/frontend/src/CatalogPanel.js
+++ b/frontend/src/CatalogPanel.js
@@ -1,6 +1,8 @@
 import axios from "axios";
 import React, { useEffect, useState, useCallback } from "react";
 
+const API_BASE = process.env.REACT_APP_API_BASE || "";
+
 export default function CatalogPanel({
   activeUser,
   websocket, // WebSocket connection from parent
@@ -20,7 +22,7 @@ export default function CatalogPanel({
   const fetchSets = async () => {
     setLoadingSets(true);
     try {
-      const res = await axios.get('http://localhost:5000/catalog-sets');
+      const res = await axios.get(`${API_BASE}/catalog-sets`);
       setSets(res.data || []);
     } catch (err) {
       console.error('Error fetching sets:', err);
@@ -34,7 +36,7 @@ export default function CatalogPanel({
     setSelectedSet(setId);
     setLoadingSetProducts(true);
     try {
-      const res = await axios.get('http://localhost:5000/catalog-set-products', { 
+      const res = await axios.get(`${API_BASE}/catalog-set-products`, {
         params: { set_id: setId } 
       });
       setSetProducts(res.data || []);
@@ -108,7 +110,7 @@ export default function CatalogPanel({
     try {
       // Background HTTP call to actually send via WhatsApp
       await axios.post(
-        "http://localhost:5000/send-catalog-item",
+        `${API_BASE}/send-catalog-item`,
         new URLSearchParams({
           user_id: activeUser.user_id,
           product_retailer_id: item.retailer_id,
@@ -150,7 +152,7 @@ export default function CatalogPanel({
 
     try {
       await axios.post(
-        "http://localhost:5000/send-catalog-set",
+        `${API_BASE}/send-catalog-set`,
         new URLSearchParams({
           user_id: activeUser.user_id,
           product_ids: JSON.stringify(setProducts.map(item => item.retailer_id)),
@@ -195,7 +197,7 @@ export default function CatalogPanel({
 
     try {
       await axios.post(
-        "http://localhost:5000/send-set-images",
+        `${API_BASE}/send-set-images`,
         new URLSearchParams({
           user_id: activeUser.user_id,
           images: JSON.stringify(selectedImages),
@@ -260,7 +262,7 @@ export default function CatalogPanel({
       setLoading(true);
       setResult("");
       try {
-        const res = await axios.post("http://localhost:5000/refresh-catalog-cache");
+        const res = await axios.post(`${API_BASE}/refresh-catalog-cache`);
         setResult(`✅ Catalog refreshed: ${res.data.count} products`);
         if (onRefresh) onRefresh();
       } catch (err) {

--- a/frontend/src/ChatWindow.js
+++ b/frontend/src/ChatWindow.js
@@ -6,6 +6,12 @@ import EmojiPicker from 'emoji-picker-react';
 import CatalogPanel from "./CatalogPanel";
 import { v4 as uuidv4 } from 'uuid'; // If not already imported
 
+// API and WebSocket endpoints
+const API_BASE = process.env.REACT_APP_API_BASE || '';
+const WS_BASE =
+  process.env.REACT_APP_WS_URL ||
+  `${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${window.location.host}/ws/`;
+
 const sortByTime = (list = []) =>
   [...list].sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp));
 
@@ -103,7 +109,7 @@ export default function ChatWindow({ activeUser }) {
   useEffect(() => {
     if (!activeUser?.user_id) return;
     
-    const websocket = new WebSocket(`ws://localhost:5000/ws/${activeUser.user_id}`);
+    const websocket = new WebSocket(`${WS_BASE}${activeUser.user_id}`);
     setWs(websocket); // store in state
     
     websocket.onopen = () => {
@@ -199,7 +205,7 @@ export default function ChatWindow({ activeUser }) {
   useEffect(() => {
     async function fetchAllProducts() {
       try {
-        const res = await axios.get("http://localhost:5000/all-catalog-products");
+        const res = await axios.get(`${API_BASE}/all-catalog-products`);
         const lookup = {};
         res.data.forEach(prod => {
           lookup[String(prod.retailer_id)] = {
@@ -221,7 +227,7 @@ export default function ChatWindow({ activeUser }) {
     if (!activeUser?.user_id) return [];
     try {
       const res = await axios.get(
-        `http://localhost:5000/messages/${activeUser.user_id}?offset=${off}&limit=${MESSAGE_LIMIT}`,
+        `${API_BASE}/messages/${activeUser.user_id}?offset=${off}&limit=${MESSAGE_LIMIT}`,
         { signal }
       );
       const data = res.data;
@@ -304,7 +310,7 @@ export default function ChatWindow({ activeUser }) {
     } else {
       // Fallback to HTTP
       try {
-        await axios.post('http://localhost:5000/send-message', {
+        await axios.post(`${API_BASE}/send-message`, {
           user_id: activeUser.user_id,
           type: 'text',
           message: text,
@@ -331,7 +337,7 @@ export default function ChatWindow({ activeUser }) {
       formData.append('user_id', activeUser.user_id);
       formData.append('media_type', 'audio');
       try {
-        await axios.post('http://localhost:5000/send-media', formData);
+        await axios.post(`${API_BASE}/send-media`, formData);
         // WebSocket will handle the real-time update
       } catch (err) {
         console.error("Audio upload error:", err);
@@ -344,7 +350,7 @@ export default function ChatWindow({ activeUser }) {
       formData.append('user_id', activeUser.user_id);
       formData.append('media_type', 'audio');
       try {
-        await axios.post('http://localhost:5000/send-media', formData);
+        await axios.post(`${API_BASE}/send-media`, formData);
         fetchMessages();
       } catch (err) {
         console.error("Audio upload error:", err);
@@ -398,7 +404,7 @@ export default function ChatWindow({ activeUser }) {
       );
     } else {
       axios.post(
-        `http://localhost:5000/conversations/${activeUser.user_id}/mark-read`,
+        `${API_BASE}/conversations/${activeUser.user_id}/mark-read`,
         { message_ids: unreadIds }
       ).catch(() => {});
     }
@@ -482,7 +488,7 @@ export default function ChatWindow({ activeUser }) {
       formData.append("media_type", "image");
       
       try {
-        const response = await axios.post("http://localhost:5000/send-media", formData, {
+        const response = await axios.post(`${API_BASE}/send-media`, formData, {
           onUploadProgress: (e) => {
             setPendingImages(images => {
               let copy = [...images];

--- a/frontend/src/ImageGroupBubble.js
+++ b/frontend/src/ImageGroupBubble.js
@@ -4,7 +4,7 @@ import React, { useState, useCallback } from "react";
 function getSafeMediaUrl(raw) {
   if (!raw) return "";
   if (/^https?:\/\//i.test(raw)) return raw;
-  const base = process.env.REACT_APP_API_BASE || "http://localhost:5000";
+  const base = process.env.REACT_APP_API_BASE || "";
   return `${base.replace(/\/$/, "")}/${raw.replace(/^\/+/, "")}`;
 }
 

--- a/frontend/src/ImageUploader.js
+++ b/frontend/src/ImageUploader.js
@@ -6,7 +6,7 @@ export default function ImageUploader({ userId, onImagesSent, ws }) {
   const fileInputRef = useRef();
 
   // Utility to get API URL
-  const API_BASE = process.env.REACT_APP_API_BASE || "http://localhost:5000";
+  const API_BASE = process.env.REACT_APP_API_BASE || "";
 
   // Function to handle upload - now compatible with ChatWindow's approach
   const handleFileUpload = async (files) => {

--- a/frontend/src/MessageBubble.js
+++ b/frontend/src/MessageBubble.js
@@ -15,7 +15,7 @@ const ICONS = {
 function getSafeMediaUrl(raw) {
   if (!raw) return "";
   if (/^https?:\/\//i.test(raw)) return raw;
-  const base = process.env.REACT_APP_API_BASE || "http://localhost:5000";
+  const base = process.env.REACT_APP_API_BASE || "";
   return `${base.replace(/\/$/, "")}/${raw.replace(/^\/+/, "")}`;
 }
 

--- a/frontend/src/ShopifyIntegrationsPanel.js
+++ b/frontend/src/ShopifyIntegrationsPanel.js
@@ -3,7 +3,7 @@ import { FaShopify } from "react-icons/fa";
 import axios from "axios";
 
 export default function ShopifyIntegrationsPanel({ activeUser }) {
-  const API_BASE = process.env.REACT_APP_API_BASE || "http://localhost:5000";
+  const API_BASE = process.env.REACT_APP_API_BASE || "";
 
   const [customer, setCustomer] = useState(null);
   const [loading, setLoading] = useState(false);

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -4,8 +4,8 @@ import axios from 'axios';
 const baseUrl =
   process.env.REACT_APP_API_BASE ||
   process.env.REACT_APP_API_URL || // Accept either for portability
-  process.env.REACT_APP_BACKEND_URL || 
-  "http://localhost:5000";
+  process.env.REACT_APP_BACKEND_URL ||
+  "";
 
 const api = axios.create({
   baseURL: baseUrl


### PR DESCRIPTION
## Summary
- remove localhost defaults from frontend
- use `REACT_APP_API_BASE` and `REACT_APP_WS_URL`
- update README with environment variable build instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6881363b6118832188c83d3432d7b130