### PR TITLE
Fix ephemeral DB issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ gcloud run deploy whatsapp-backend \
 
 Replace the values with the credentials for your Shopify store. Alternatively use the `IRRAKIDS_*` or `IRRANOVA_*` variable names if those are available.
 
+## SQLite database
+
+Messages are stored in a local SQLite file. By default the backend writes to
+`data/whatsapp_messages.db`. The directory is created automatically if it does
+not exist.
+
+When deploying to providers with ephemeral filesystems, point the `DB_PATH`
+environment variable at a location backed by a persistent volume so that chat
+history is retained across restarts.
+
 ## Frontend build
 
 Before running the backend make sure the React frontend is compiled:

--- a/backend/main.py
+++ b/backend/main.py
@@ -24,7 +24,7 @@ from fastapi.staticfiles import StaticFiles
 PORT = int(os.getenv("PORT", "8080"))
 BASE_URL = os.getenv("BASE_URL", f"http://localhost:{PORT}")
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379")
-DB_PATH = os.getenv("DB_PATH", "/tmp/whatsapp_messages.db")
+DB_PATH = os.getenv("DB_PATH", "data/whatsapp_messages.db")
 # Anything that **must not** be baked in the image (tokens, IDs …) is
 # already picked up with os.getenv() further below. Keep it that way.
 


### PR DESCRIPTION
## Summary
- default DB path to a persistent `data/whatsapp_messages.db`
- document how to persist chat data with the `DB_PATH` variable

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688168a1e4d88321b495b0ffc6232898