### PR TITLE
Document test dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,26 @@ The backend stores a cached copy of the catalog in `backend/catalog_cache.json`.
 2. Call the `/refresh-catalog-cache` endpoint manually.
 
 The cache file must exist for the `catalog-sets` and `catalog-set-products` endpoints to return data.
+
+## Running Tests
+
+The unit tests in `tests/` rely on a few additional packages beyond the standard
+backend requirements.
+Install the backend dependencies and the following test packages:
+
+- `pytest`
+- `pytest-asyncio`
+- `fastapi`
+- `aiosqlite`
+
+You can install everything with:
+
+```bash
+pip install -r backend/requirements.txt -r requirements-test.txt
+```
+
+Then run the suite with:
+
+```bash
+pytest
+```

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,4 @@
+pytest
+pytest-asyncio
+fastapi
+aiosqlite


### PR DESCRIPTION
## Summary
- document packages needed to run tests
- add requirements-test.txt for convenience

## Testing
- `pip install -q -r backend/requirements.txt -r requirements-test.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68835e5fe9148321910b528872cf0ba5