### PR TITLE
Fix S3 URL building

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Uploaded media files can be stored in an S3 bucket by setting the `MEDIA_BUCKET`
 variable to your bucket name. If your provider uses a custom endpoint (for
 example Cloudflare R2), set `S3_ENDPOINT_URL` to that endpoint URL (e.g.
 `https://<account-id>.r2.cloudflarestorage.com`). When configured, uploaded
-media will be copied to the bucket and served from its public URL.
+media will be copied to the bucket and served from that endpoint using
+path-style URLs.
 
 When deploying to providers with ephemeral filesystems, point the `DB_PATH`
 environment variable at a location backed by a persistent volume so that chat

--- a/backend/main.py
+++ b/backend/main.py
@@ -1139,7 +1139,10 @@ class MessageProcessor:
                 await asyncio.get_event_loop().run_in_executor(
                     None, lambda: s3.upload_file(str(file_path), MEDIA_BUCKET, filename)
                 )
-                bucket_url = f"https://{MEDIA_BUCKET}.s3.amazonaws.com/{filename}"
+                if S3_ENDPOINT_URL:
+                    bucket_url = f"{S3_ENDPOINT_URL}/{MEDIA_BUCKET}/{filename}"
+                else:
+                    bucket_url = f"https://{MEDIA_BUCKET}.s3.amazonaws.com/{filename}"
 
             return str(file_path), bucket_url
 
@@ -1554,7 +1557,10 @@ async def send_media(
                 await asyncio.get_event_loop().run_in_executor(
                     None, lambda: s3.upload_file(str(file_path), MEDIA_BUCKET, filename)
                 )
-                media_url = f"https://{MEDIA_BUCKET}.s3.amazonaws.com/{filename}"
+                if S3_ENDPOINT_URL:
+                    media_url = f"{S3_ENDPOINT_URL}/{MEDIA_BUCKET}/{filename}"
+                else:
+                    media_url = f"https://{MEDIA_BUCKET}.s3.amazonaws.com/{filename}"
             else:
                 media_url = f"{BASE_URL}/media/{filename}"
 

--- a/tests/test_send_media.py
+++ b/tests/test_send_media.py
@@ -1,0 +1,34 @@
+from fastapi.testclient import TestClient
+from backend import main
+
+
+def test_send_media_uses_s3_endpoint(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(main, "MEDIA_BUCKET", "testbucket")
+    monkeypatch.setattr(main, "S3_ENDPOINT_URL", "https://endpoint.test")
+
+    class DummyS3:
+        def upload_file(self, src, bucket, key):
+            self.src = src
+            self.bucket = bucket
+            self.key = key
+
+    dummy = DummyS3()
+    monkeypatch.setattr(main.boto3, "client", lambda *a, **k: dummy)
+
+    async def fake_process(data):
+        return {"ok": True}
+
+    monkeypatch.setattr(main.message_processor, "process_outgoing_message", fake_process)
+
+    with TestClient(main.app) as client:
+        resp = client.post(
+            "/send-media",
+            data={"user_id": "u1", "media_type": "image", "caption": "", "price": ""},
+            files={"files": ("x.jpg", b"data", "image/jpeg")},
+        )
+
+    assert resp.status_code == 200
+    result = resp.json()["messages"][0]
+    expected_url = f"https://endpoint.test/testbucket/{result['filename']}"
+    assert result["media_url"] == expected_url


### PR DESCRIPTION
## Summary
- adjust S3 URL construction in `backend/main.py`
- document path‑style URLs when using `S3_ENDPOINT_URL`
- test `/send-media` endpoint URL generation

## Testing
- `pip install -r requirements-test.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6883e3d003988321b6cfe1206792751f