### PR TITLE
Handle media URLs

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -369,6 +369,7 @@ class DatabaseManager:
             "caption",
             "media_path",
             "timestamp",
+            "url",  # store public URL for media
         }
 
     async def _get_pool(self):
@@ -425,6 +426,7 @@ class DatabaseManager:
                     status         TEXT  DEFAULT 'sending',
                     price          TEXT,
                     caption        TEXT,
+                    url            TEXT,
                     media_path     TEXT,
                     timestamp      TEXT  DEFAULT CURRENT_TIMESTAMP
                 );
@@ -607,6 +609,7 @@ class DatabaseManager:
             "status": status,
             "price": message.get("price"),
             "caption": message.get("caption"),
+            "url": message.get("url"),
             "media_path": message.get("media_path"),
             "timestamp": message.get("timestamp"),
         }

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -23,7 +23,7 @@ class FakeConn:
 import aiosqlite
 
 @pytest.mark.asyncio
-async def test_upsert_message_filters_unknown_keys(tmp_path):
+async def test_upsert_message_saves_url(tmp_path):
     db_path = tmp_path / "db.sqlite"
     dm = DatabaseManager(db_path=str(db_path))
     await dm.init_db()
@@ -34,13 +34,13 @@ async def test_upsert_message_filters_unknown_keys(tmp_path):
         "from_me": 0,
         "status": "received",
         "timestamp": "t",
-        "url": "http://bad",  # unknown column should be ignored
+        "url": "http://example.com/img.jpg",
     })
     msgs = await dm.get_messages("user")
     assert len(msgs) == 1
     msg = msgs[0]
     assert msg["wa_message_id"] == "x1"
-    assert "url" not in msg
+    assert msg["url"] == "http://example.com/img.jpg"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- track `url` for media messages in the DB
- verify url persistence in database manager tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6883ed32e54c83219e6d86c3028b684a