### PR TITLE
Install ffmpeg and document requirement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN npm run build
 
 FROM python:3.12-slim
 
+RUN apt-get update && apt-get install -y ffmpeg && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 COPY . .
 COPY --from=frontend-builder /app/frontend/build ./frontend/build

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This project contains a FastAPI backend and React frontend for integrating Whats
 
 **Note:** File upload endpoints require the `python-multipart` package. Make sure this dependency is installed when deploying the backend.
 
+**Note:** Audio messaging relies on `ffmpeg` for processing voice notes. The provided Dockerfile installs this package automatically.
+
 ## Shopify Credentials
 
 The backend supports multiple environment variable prefixes to load Shopify credentials. It will use the first complete set it finds.


### PR DESCRIPTION
## Summary
- add ffmpeg installation to the runtime layer of the Dockerfile
- document ffmpeg requirement for audio messaging in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6883f00a6f4c8321926feecd44a079dc