### PR TITLE
Raise HTTP errors for media upload failures

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1542,7 +1542,7 @@ async def send_media(
                 async with aiofiles.open(file_path, "wb") as f:
                     await f.write(content)
             except Exception as exc:
-                return {"error": f"Failed to save file: {exc}", "status": "failed"}
+                raise HTTPException(status_code=500, detail=f"Failed to save file: {exc}")
 
             # ---------- AUDIO-ONLY: convert WebM → OGG ----------
             if media_type == "audio" and file_extension.lower() != ".ogg":
@@ -1552,7 +1552,7 @@ async def send_media(
                     file_path = ogg_path
                     filename = ogg_path.name
                 except Exception as exc:
-                    return {"error": f"Audio conversion failed: {exc}", "status": "failed"}
+                    raise HTTPException(status_code=500, detail=f"Audio conversion failed: {exc}")
 
             # ---------- build metadata ----------
             if MEDIA_BUCKET:
@@ -1587,6 +1587,9 @@ async def send_media(
 
         return {"status": "success", "messages": saved_results}
 
+    except HTTPException:
+        # Propagate HTTP errors to the client
+        raise
     except Exception as exc:
         print(f"❌ Error in /send-media: {exc}")
         return {"error": f"Internal server error: {exc}", "status": "failed"}

--- a/tests/test_send_media.py
+++ b/tests/test_send_media.py
@@ -32,3 +32,53 @@ def test_send_media_uses_s3_endpoint(tmp_path, monkeypatch):
     result = resp.json()["messages"][0]
     expected_url = f"https://endpoint.test/testbucket/{result['filename']}"
     assert result["media_url"] == expected_url
+
+
+def test_send_media_save_error(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(main, "MEDIA_BUCKET", None)
+
+    async def fake_open(*a, **k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(main.aiofiles, "open", fake_open)
+
+    async def fake_process(data):
+        return {"ok": True}
+
+    monkeypatch.setattr(main.message_processor, "process_outgoing_message", fake_process)
+
+    with TestClient(main.app) as client:
+        resp = client.post(
+            "/send-media",
+            data={"user_id": "u1", "media_type": "image", "caption": "", "price": ""},
+            files={"files": ("x.jpg", b"data", "image/jpeg")},
+        )
+
+    assert resp.status_code == 500
+    assert "Failed to save file" in resp.json()["detail"]
+
+
+def test_send_media_conversion_error(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(main, "MEDIA_BUCKET", None)
+
+    async def fake_convert(path):
+        raise RuntimeError("bad format")
+
+    monkeypatch.setattr(main, "convert_webm_to_ogg", fake_convert)
+
+    async def fake_process(data):
+        return {"ok": True}
+
+    monkeypatch.setattr(main.message_processor, "process_outgoing_message", fake_process)
+
+    with TestClient(main.app) as client:
+        resp = client.post(
+            "/send-media",
+            data={"user_id": "u1", "media_type": "audio", "caption": "", "price": ""},
+            files={"files": ("x.webm", b"data", "audio/webm")},
+        )
+
+    assert resp.status_code == 500
+    assert "Audio conversion failed" in resp.json()["detail"]


### PR DESCRIPTION
## Summary
- return HTTP 500 when media saving or conversion fails
- keep HTTPExceptions unhandled so FastAPI propagates them
- test error cases in `/send-media`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6883f017e05c832189b24fde58540bad