### PR TITLE
Handle missing media URL column

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ CREATE INDEX IF NOT EXISTS idx_msg_wa_id ON messages(wa_message_id);
 CREATE INDEX IF NOT EXISTS idx_msg_temp_id ON messages(temp_id);
 ```
 
+Newer releases also store public URLs for uploaded media in a `url` column.
+Starting the backend will automatically add this column when missing, so you do
+not need to recreate an existing database.
+
 ## Frontend build
 
 Before running the backend make sure the React frontend is compiled:


### PR DESCRIPTION
## Summary
- add helper to add DB columns if missing
- ensure `url` column exists during init_db
- clarify schema upgrade notes in README
- test DB upgrade path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6883f47fb8308321b475fd367efcac21