### PR TITLE
Add MEDIA_PUBLIC_URL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,14 @@ to a valid connection string. When this variable is present the backend will use
 `asyncpg` to communicate with PostgreSQL.
 
 Uploaded media files can be stored in an S3 bucket by setting the `MEDIA_BUCKET`
-variable to your bucket name. If your provider uses a custom endpoint (for
-example Cloudflare R2), set `S3_ENDPOINT_URL` to that endpoint URL (e.g.
-`https://<account-id>.r2.cloudflarestorage.com`). When configured, uploaded
-media will be copied to the bucket and served from that endpoint using
-path-style URLs.
+variable to your bucket name. `S3_ENDPOINT_URL` should point to the S3 API
+endpoint (for example `https://<account-id>.r2.cloudflarestorage.com`). When
+configured, uploaded media will be copied to the bucket and served from that
+endpoint using path-style URLs. If the public URL for your bucket differs from
+the API endpoint you can set `MEDIA_PUBLIC_URL` to that domain (e.g.
+`https://pub-<account-id>.r2.dev` or your own host). When defined the backend
+returns URLs based on `MEDIA_PUBLIC_URL` while still using `S3_ENDPOINT_URL` to
+interact with the bucket.
 
 When deploying to providers with ephemeral filesystems, point the `DB_PATH`
 environment variable at a location backed by a persistent volume so that chat

--- a/backend/main.py
+++ b/backend/main.py
@@ -31,6 +31,8 @@ DATABASE_URL = os.getenv("DATABASE_URL")  # optional PostgreSQL URL
 MEDIA_BUCKET = os.getenv("MEDIA_BUCKET")  # optional S3 bucket for media
 # Custom S3 endpoint for providers like Cloudflare R2
 S3_ENDPOINT_URL = os.getenv("S3_ENDPOINT_URL")
+# Public base URL for accessing uploaded media. Defaults to the S3 endpoint.
+MEDIA_PUBLIC_URL = os.getenv("MEDIA_PUBLIC_URL", S3_ENDPOINT_URL)
 # Anything that **must not** be baked in the image (tokens, IDs …) is
 # already picked up with os.getenv() further below. Keep it that way.
 
@@ -1163,7 +1165,9 @@ class MessageProcessor:
                 await asyncio.get_event_loop().run_in_executor(
                     None, lambda: s3.upload_file(str(file_path), MEDIA_BUCKET, filename)
                 )
-                if S3_ENDPOINT_URL:
+                if MEDIA_PUBLIC_URL:
+                    bucket_url = f"{MEDIA_PUBLIC_URL}/{MEDIA_BUCKET}/{filename}"
+                elif S3_ENDPOINT_URL:
                     bucket_url = f"{S3_ENDPOINT_URL}/{MEDIA_BUCKET}/{filename}"
                 else:
                     bucket_url = f"https://{MEDIA_BUCKET}.s3.amazonaws.com/{filename}"
@@ -1581,7 +1585,9 @@ async def send_media(
                 await asyncio.get_event_loop().run_in_executor(
                     None, lambda: s3.upload_file(str(file_path), MEDIA_BUCKET, filename)
                 )
-                if S3_ENDPOINT_URL:
+                if MEDIA_PUBLIC_URL:
+                    media_url = f"{MEDIA_PUBLIC_URL}/{MEDIA_BUCKET}/{filename}"
+                elif S3_ENDPOINT_URL:
                     media_url = f"{S3_ENDPOINT_URL}/{MEDIA_BUCKET}/{filename}"
                 else:
                     media_url = f"https://{MEDIA_BUCKET}.s3.amazonaws.com/{filename}"

--- a/tests/test_send_media.py
+++ b/tests/test_send_media.py
@@ -2,10 +2,11 @@ from fastapi.testclient import TestClient
 from backend import main
 
 
-def test_send_media_uses_s3_endpoint(tmp_path, monkeypatch):
+def test_send_media_uses_media_public_url(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(main, "MEDIA_BUCKET", "testbucket")
-    monkeypatch.setattr(main, "S3_ENDPOINT_URL", "https://endpoint.test")
+    monkeypatch.setattr(main, "S3_ENDPOINT_URL", "https://s3.api.test")
+    monkeypatch.setattr(main, "MEDIA_PUBLIC_URL", "https://public.test")
 
     class DummyS3:
         def upload_file(self, src, bucket, key):
@@ -30,7 +31,7 @@ def test_send_media_uses_s3_endpoint(tmp_path, monkeypatch):
 
     assert resp.status_code == 200
     result = resp.json()["messages"][0]
-    expected_url = f"https://endpoint.test/testbucket/{result['filename']}"
+    expected_url = f"https://public.test/testbucket/{result['filename']}"
     assert result["media_url"] == expected_url
 
 


### PR DESCRIPTION
## Summary
- allow public and API S3 URLs to differ
- document the new variable in README
- adjust tests for MEDIA_PUBLIC_URL

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688412768eb88321b83e00a8676bb0cc