### PR TITLE
Switch media uploads to Google Drive

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,18 @@ To use PostgreSQL instead of SQLite, set the `DATABASE_URL` environment variable
 to a valid connection string. When this variable is present the backend will use
 `asyncpg` to communicate with PostgreSQL.
 
-Uploaded media files can be stored in an S3 bucket by setting the `MEDIA_BUCKET`
-variable to your bucket name. `S3_ENDPOINT_URL` should point to the S3 API
-endpoint (for example `https://<account-id>.r2.cloudflarestorage.com`). When
-configured, uploaded media will be copied to the bucket and served from that
-endpoint using path-style URLs. If the public URL for your bucket differs from
-the API endpoint you can set `MEDIA_PUBLIC_URL` to that domain (e.g.
-`https://pub-<account-id>.r2.dev` or your own host). When defined the backend
-returns URLs based on `MEDIA_PUBLIC_URL` while still using `S3_ENDPOINT_URL` to
-interact with the bucket.
+Uploaded media files are sent to Google Drive instead of S3. Set
+`GOOGLE_DRIVE_FOLDER_ID` to the target Drive folder and provide a service
+account JSON key via `GOOGLE_DRIVE_CREDENTIALS_FILE`. The backend will upload
+files using these credentials and share them publicly so anyone with the link
+can view the file. The returned URLs use the standard
+`https://drive.google.com/uc?id=<file_id>` format.
+
+Create a service account in your Google Cloud project and enable the Drive API.
+Download the JSON key for this account and set `GOOGLE_DRIVE_CREDENTIALS_FILE`
+to its path. Share the destination folder with the service account's email so it
+can upload files. The backend will set each uploaded file to be accessible by
+anyone who has the link.
 
 When deploying to providers with ephemeral filesystems, point the `DB_PATH`
 environment variable at a location backed by a persistent volume so that chat

--- a/backend/google_drive.py
+++ b/backend/google_drive.py
@@ -1,0 +1,44 @@
+import asyncio
+import os
+from pathlib import Path
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+from googleapiclient.http import MediaFileUpload
+
+GOOGLE_DRIVE_FOLDER_ID = os.getenv("GOOGLE_DRIVE_FOLDER_ID")
+GOOGLE_DRIVE_CREDENTIALS_FILE = os.getenv("GOOGLE_DRIVE_CREDENTIALS_FILE")
+
+_SCOPES = ["https://www.googleapis.com/auth/drive"]
+
+
+def _get_service():
+    if not GOOGLE_DRIVE_CREDENTIALS_FILE:
+        raise RuntimeError("GOOGLE_DRIVE_CREDENTIALS_FILE is not set")
+    creds = service_account.Credentials.from_service_account_file(
+        GOOGLE_DRIVE_CREDENTIALS_FILE, scopes=_SCOPES
+    )
+    return build("drive", "v3", credentials=creds)
+
+
+def _upload_sync(file_path: str) -> str:
+    service = _get_service()
+    metadata = {"name": Path(file_path).name}
+    if GOOGLE_DRIVE_FOLDER_ID:
+        metadata["parents"] = [GOOGLE_DRIVE_FOLDER_ID]
+    media = MediaFileUpload(file_path, resumable=False)
+    file = (
+        service.files()
+        .create(body=metadata, media_body=media, fields="id")
+        .execute()
+    )
+    file_id = file.get("id")
+    service.permissions().create(
+        fileId=file_id, body={"role": "reader", "type": "anyone"}
+    ).execute()
+    return f"https://drive.google.com/uc?id={file_id}"
+
+
+async def upload_file_to_drive(file_path: str) -> str:
+    """Upload a file to Google Drive and return a public URL."""
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(None, _upload_sync, file_path)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -51,4 +51,3 @@ aiosqlite
 aiofiles
 redis
 asyncpg
-boto3


### PR DESCRIPTION
## Summary
- add helper to upload files to Google Drive
- store Google Drive credentials and folder ID from env vars
- upload media messages to Drive instead of S3
- document Google Drive variables
- adjust unit tests and remove boto3 dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6884995bf58c8321a3d5951dde2b6088