### PR TITLE
Adjust Google Drive public URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ credentials either through `GOOGLE_DRIVE_CREDENTIALS_FILE` or
 otherwise the JSON string is read. The backend uploads files using these
 credentials and shares them publicly so anyone with the link can view the
 file. The returned URLs use the standard
-`https://drive.google.com/uc?export=download&id=<file_id>` format.
+`https://drive.google.com/uc?id=<file_id>` format.
 
 Create a service account in your Google Cloud project and enable the Drive API.
 Download the JSON key for this account and either mount it on disk and set

--- a/backend/google_drive.py
+++ b/backend/google_drive.py
@@ -47,7 +47,7 @@ def _upload_sync(file_path: str) -> str:
     service.permissions().create(
         fileId=file_id, body={"role": "reader", "type": "anyone"}
     ).execute()
-    return f"https://drive.google.com/uc?export=download&id={file_id}"
+    return f"https://drive.google.com/uc?id={file_id}"
 
 
 async def upload_file_to_drive(file_path: str) -> str:

--- a/tests/test_send_media.py
+++ b/tests/test_send_media.py
@@ -128,7 +128,7 @@ def test_drive_json_credentials(tmp_path, monkeypatch):
 
     url = google_drive._upload_sync(str(file_path))
 
-    assert url == "https://drive.google.com/uc?export=download&id=abc"
+    assert url == "https://drive.google.com/uc?id=abc"
     assert captured["info"]["foo"] == "bar"
     assert captured["build"]
 


### PR DESCRIPTION
## Summary
- return Drive URLs without export=download
- document new Drive URL format
- update tests for Drive URL

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6884c3d4d7c0832189ea96fe1679f158