### PR TITLE
Centralize auth handling in frontend API calls

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,7 +3,7 @@ import React, { useEffect, useState, useRef } from 'react';
 import ChatList from './ChatList';
 import ChatWindow from './ChatWindow';
 import ShopifyIntegrationsPanel from './ShopifyIntegrationsPanel';
-import axios from 'axios';
+import api from './api';
 import { loadConversations, saveConversations } from './chatStorage';
 
 // Read API base from env for production/dev compatibility
@@ -23,7 +23,7 @@ export default function App() {
   // Fetch all conversations for chat list
   const fetchConversations = async () => {
     try {
-      const res = await axios.get(`${API_BASE}/conversations`);
+      const res = await api.get(`${API_BASE}/conversations`);
       setConversations(res.data);
       saveConversations(res.data);
     } catch (err) {
@@ -38,7 +38,7 @@ export default function App() {
   // Fetch ALL products in catalog and build a lookup for order message rendering
   const fetchCatalogProducts = async () => {
     try {
-      const res = await axios.get(`${API_BASE}/catalog-all-products`);
+      const res = await api.get(`${API_BASE}/catalog-all-products`);
       const allProducts = res.data || [];
 
       // Only keep in-stock items

--- a/frontend/src/CatalogPanel.js
+++ b/frontend/src/CatalogPanel.js
@@ -1,4 +1,4 @@
-import axios from "axios";
+import api from "./api";
 import React, { useEffect, useState, useCallback } from "react";
 
 const API_BASE = process.env.REACT_APP_API_BASE || "";
@@ -22,7 +22,7 @@ export default function CatalogPanel({
   const fetchSets = async () => {
     setLoadingSets(true);
     try {
-      const res = await axios.get(`${API_BASE}/catalog-sets`);
+      const res = await api.get(`${API_BASE}/catalog-sets`);
       setSets(res.data || []);
     } catch (err) {
       console.error('Error fetching sets:', err);
@@ -36,7 +36,7 @@ export default function CatalogPanel({
     setSelectedSet(setId);
     setLoadingSetProducts(true);
     try {
-      const res = await axios.get(`${API_BASE}/catalog-set-products`, {
+      const res = await api.get(`${API_BASE}/catalog-set-products`, {
         params: { set_id: setId } 
       });
       setSetProducts(res.data || []);
@@ -109,7 +109,7 @@ export default function CatalogPanel({
 
     try {
       // Background HTTP call to actually send via WhatsApp
-      await axios.post(
+      await api.post(
         `${API_BASE}/send-catalog-item`,
         new URLSearchParams({
           user_id: activeUser.user_id,
@@ -151,7 +151,7 @@ export default function CatalogPanel({
     }
 
     try {
-      await axios.post(
+      await api.post(
         `${API_BASE}/send-catalog-set`,
         new URLSearchParams({
           user_id: activeUser.user_id,
@@ -196,7 +196,7 @@ export default function CatalogPanel({
     }
 
     try {
-      await axios.post(
+      await api.post(
         `${API_BASE}/send-set-images`,
         new URLSearchParams({
           user_id: activeUser.user_id,
@@ -262,7 +262,7 @@ export default function CatalogPanel({
       setLoading(true);
       setResult("");
       try {
-        const res = await axios.post(`${API_BASE}/refresh-catalog-cache`);
+        const res = await api.post(`${API_BASE}/refresh-catalog-cache`);
         setResult(`✅ Catalog refreshed: ${res.data.count} products`);
         if (onRefresh) onRefresh();
       } catch (err) {

--- a/frontend/src/ChatWindow.js
+++ b/frontend/src/ChatWindow.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef, useCallback } from 'react';
-import axios from 'axios';
+import api from './api';
 import MessageBubble from './MessageBubble';
 import useAudioRecorder from './useAudioRecorder';
 import EmojiPicker from 'emoji-picker-react';
@@ -217,7 +217,7 @@ export default function ChatWindow({ activeUser }) {
   useEffect(() => {
     async function fetchAllProducts() {
       try {
-        const res = await axios.get(`${API_BASE}/all-catalog-products`);
+        const res = await api.get(`${API_BASE}/all-catalog-products`);
         const lookup = {};
         res.data.forEach(prod => {
           lookup[String(prod.retailer_id)] = {
@@ -238,7 +238,7 @@ export default function ChatWindow({ activeUser }) {
   const fetchMessages = async ({ offset: off = 0, append = false } = {}, signal) => {
     if (!activeUser?.user_id) return [];
     try {
-      const res = await axios.get(
+      const res = await api.get(
         `${API_BASE}/messages/${activeUser.user_id}?offset=${off}&limit=${MESSAGE_LIMIT}`,
         { signal }
       );
@@ -267,7 +267,7 @@ export default function ChatWindow({ activeUser }) {
       setHasMore(data.length >= MESSAGE_LIMIT);
       return data;
     } catch (err) {
-      if (axios.isCancel(err) || err.name === 'CanceledError') return [];
+      if (api.isCancel(err) || err.name === 'CanceledError') return [];
       console.error("Failed to fetch messages", err);
       // Error while fetching, fall back to cached messages
       const cached = await loadMessages(activeUser.user_id);
@@ -340,7 +340,7 @@ export default function ChatWindow({ activeUser }) {
     } else {
       // Fallback to HTTP
       try {
-        await axios.post(`${API_BASE}/send-message`, {
+        await api.post(`${API_BASE}/send-message`, {
           user_id: activeUser.user_id,
           type: 'text',
           message: text,
@@ -367,7 +367,7 @@ export default function ChatWindow({ activeUser }) {
       formData.append('user_id', activeUser.user_id);
       formData.append('media_type', 'audio');
       try {
-        await axios.post(`${API_BASE}/send-media`, formData);
+        await api.post(`${API_BASE}/send-media`, formData);
         // WebSocket will handle the real-time update
       } catch (err) {
         console.error("Audio upload error:", err);
@@ -380,7 +380,7 @@ export default function ChatWindow({ activeUser }) {
       formData.append('user_id', activeUser.user_id);
       formData.append('media_type', 'audio');
       try {
-        await axios.post(`${API_BASE}/send-media`, formData);
+        await api.post(`${API_BASE}/send-media`, formData);
         fetchMessages();
       } catch (err) {
         console.error("Audio upload error:", err);
@@ -439,7 +439,7 @@ export default function ChatWindow({ activeUser }) {
         JSON.stringify({ type: 'mark_as_read', message_ids: unreadIds })
       );
     } else {
-      axios.post(
+      api.post(
         `${API_BASE}/conversations/${activeUser.user_id}/mark-read`,
         { message_ids: unreadIds }
       ).catch(() => {});
@@ -524,7 +524,7 @@ export default function ChatWindow({ activeUser }) {
       formData.append("media_type", "image");
       
       try {
-        const response = await axios.post(`${API_BASE}/send-media`, formData, {
+        const response = await api.post(`${API_BASE}/send-media`, formData, {
           onUploadProgress: (e) => {
             setPendingImages(images => {
               let copy = [...images];

--- a/frontend/src/ImageUploader.js
+++ b/frontend/src/ImageUploader.js
@@ -1,4 +1,5 @@
 import React, { useRef, useState } from 'react';
+import fetchWithAuth from './fetchWithAuth';
 
 export default function ImageUploader({ userId, onImagesSent, ws }) {
   const [isUploading, setIsUploading] = useState(false);
@@ -25,7 +26,7 @@ export default function ImageUploader({ userId, onImagesSent, ws }) {
         // Send via WebSocket if available (like ChatWindow does)
         if (ws && ws.readyState === WebSocket.OPEN) {
           // For WebSocket, we still use HTTP upload but let WS handle real-time updates
-          const response = await fetch(`${API_BASE}/send-media`, {
+          const response = await fetchWithAuth(`${API_BASE}/send-media`, {
             method: 'POST',
             body: formData,
           });
@@ -39,7 +40,7 @@ export default function ImageUploader({ userId, onImagesSent, ws }) {
           // WebSocket will handle the UI update automatically
         } else {
           // Fallback to HTTP-only approach
-          const response = await fetch(`${API_BASE}/send-media`, {
+          const response = await fetchWithAuth(`${API_BASE}/send-media`, {
             method: 'POST',
             body: formData,
           });

--- a/frontend/src/ShopifyIntegrationsPanel.js
+++ b/frontend/src/ShopifyIntegrationsPanel.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { FaShopify } from "react-icons/fa";
-import axios from "axios";
+import api from "./api";
 
 export default function ShopifyIntegrationsPanel({ activeUser }) {
   const API_BASE = process.env.REACT_APP_API_BASE || "";
@@ -51,7 +51,7 @@ export default function ShopifyIntegrationsPanel({ activeUser }) {
 
   // Fetch shipping methods on mount
   useEffect(() => {
-    axios.get(`${API_BASE}/shopify-shipping-options`)
+    api.get(`${API_BASE}/shopify-shipping-options`)
       .then(res => {
         setShippingOptions(res.data);
         if (res.data.length) setDeliveryOption(res.data[0].name);
@@ -74,7 +74,7 @@ export default function ShopifyIntegrationsPanel({ activeUser }) {
       return;
     }
     setLoading(true);
-    axios
+    api
       .get(`${API_BASE}/search-customer?phone_number=${encodeURIComponent(activeUser.phone)}`)
       .then((res) => {
         setCustomer(res.data);
@@ -111,7 +111,7 @@ export default function ShopifyIntegrationsPanel({ activeUser }) {
     }
     const timeoutId = setTimeout(async () => {
       try {
-        const res = await axios.get(`${API_BASE}/shopify-products?q=${encodeURIComponent(productSearch)}`);
+        const res = await api.get(`${API_BASE}/shopify-products?q=${encodeURIComponent(productSearch)}`);
         setProducts(res.data || []);
       } catch {
         setProducts([]);
@@ -124,7 +124,7 @@ export default function ShopifyIntegrationsPanel({ activeUser }) {
   const handleAddByVariantId = async () => {
     if (!variantIdInput) return;
     try {
-      const res = await axios.get(`${API_BASE}/shopify-variant/${variantIdInput}`);
+      const res = await api.get(`${API_BASE}/shopify-variant/${variantIdInput}`);
       if (res.data) {
         setSelectedItems(items => [...items, { variant: res.data, quantity: 1, discount: 0 }]);
       }
@@ -183,7 +183,7 @@ export default function ShopifyIntegrationsPanel({ activeUser }) {
 
     setIsCreating(true);
     try {
-      await axios.post(`${API_BASE}/create-shopify-order`, orderPayload);
+      await api.post(`${API_BASE}/create-shopify-order`, orderPayload);
       setSelectedItems([]);
       setErrorMsg("");
       alert("Order created successfully!");

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -11,4 +11,20 @@ const api = axios.create({
   baseURL: baseUrl
 });
 
+// Redirect to login on auth errors
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    const status = error?.response?.status;
+    const detail = error?.response?.data?.detail;
+    if (status === 401 || detail === 'Merchant login required') {
+      window.location.href = '/login';
+    }
+    return Promise.reject(error);
+  }
+);
+
+// expose axios utility helpers on the instance
+api.isCancel = axios.isCancel;
+
 export default api;

--- a/frontend/src/fetchWithAuth.js
+++ b/frontend/src/fetchWithAuth.js
@@ -1,0 +1,16 @@
+export default async function fetchWithAuth(url, options = {}) {
+  const response = await fetch(url, options);
+  if (response.status === 401) {
+    window.location.href = '/login';
+    return response;
+  }
+  try {
+    const data = await response.clone().json();
+    if (data?.detail === 'Merchant login required') {
+      window.location.href = '/login';
+    }
+  } catch (e) {
+    // ignore JSON parse errors
+  }
+  return response;
+}


### PR DESCRIPTION
## Summary
- add shared Axios instance with auth redirect interceptor
- switch components to shared instance
- wrap fetch uploads with auth-aware helper

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `pytest` *(fails: Missing Shopify environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_688e47962b0083219499bc043d29fa2b