### PR TITLE
Use interactive product list for catalog messages

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -248,11 +248,23 @@ class WhatsAppMessenger:
             data = {
                 "messaging_product": "whatsapp",
                 "to": user_id,
-                "type": "multi_product",
-                "multi_product": {
-                    "catalog_id": config.CATALOG_ID,
-                    "products": [{"product_retailer_id": rid} for rid in chunk]
-                }
+                "type": "interactive",
+                "interactive": {
+                    "type": "product_list",
+                    "header": {"type": "text", "text": "Products"},
+                    "body": {"text": "Check out these products!"},
+                    "action": {
+                        "catalog_id": config.CATALOG_ID,
+                        "sections": [
+                            {
+                                "title": "Default",
+                                "product_items": [
+                                    {"product_retailer_id": rid} for rid in chunk
+                                ],
+                            }
+                        ],
+                    },
+                },
             }
             result = await self._make_request("messages", data)
             results.append(result)

--- a/tests/test_catalog_endpoints.py
+++ b/tests/test_catalog_endpoints.py
@@ -127,7 +127,9 @@ def test_send_catalog_set_all_chunks(monkeypatch):
     calls = []
 
     async def fake_make_request(endpoint, data):
-        calls.append(data["multi_product"]["products"])
+        calls.append(
+            data["interactive"]["action"]["sections"][0]["product_items"]
+        )
         return {"ok": True}
 
     monkeypatch.setattr(main.messenger, "_make_request", fake_make_request)


### PR DESCRIPTION
## Summary
- switch catalog product sending to interactive `product_list`
- adapt catalog endpoint test for new payload structure

## Testing
- `pytest tests/test_catalog_endpoints.py`
- `pytest` *(fails: async def functions are not natively supported; missing pytest-asyncio dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68aefa6359bc83218f337f914e43e203