### PR TITLE
Prefer audio uploads for WhatsApp and map ogg mimetype

### DIFF
--- a/backend/google_cloud_storage.py
+++ b/backend/google_cloud_storage.py
@@ -42,6 +42,8 @@ def _upload_sync(file_path: str, content_type: str | None = None) -> str:
 
     if content_type is None:
         content_type, _ = mimetypes.guess_type(file_path)
+        if content_type is None and file_path.lower().endswith('.ogg'):
+            content_type = 'audio/ogg'
     blob.upload_from_filename(file_path, content_type=content_type)
     blob.make_public()
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -986,15 +986,15 @@ class MessageProcessor:
                 # For media messages: support either local path upload or direct link
                 media_path = message.get("media_path")
                 media_url = message.get("url")
-                if media_url and isinstance(media_url, str) and media_url.startswith(("http://", "https://")):
-                    wa_response = await self.whatsapp_messenger.send_media_message(
-                        user_id, message["type"], media_url, message.get("caption", "")
-                    )
-                elif media_path and Path(media_path).exists():
+                if media_path and Path(media_path).exists():
                     print(f"📤 Uploading media: {media_path}")
                     media_id = await self._upload_media_to_whatsapp(media_path, message["type"])
                     wa_response = await self.whatsapp_messenger.send_media_message(
                         user_id, message["type"], media_id, message.get("caption", "")
+                    )
+                elif media_url and isinstance(media_url, str) and media_url.startswith(("http://", "https://")):
+                    wa_response = await self.whatsapp_messenger.send_media_message(
+                        user_id, message["type"], media_url, message.get("caption", "")
                     )
                 else:
                     raise Exception("No media found: require url http(s) or valid media_path")
@@ -1686,6 +1686,7 @@ async def send_media(
             message_data = {
                 "user_id": user_id,
                 "message": str(file_path),
+                # URL is kept for UI display; WhatsApp will use the uploaded media ID
                 "url": media_url,
                 "type": media_type,
                 "from_me": True,


### PR DESCRIPTION
## Summary
- map `.ogg` files to `audio/ogg` when uploading to GCS
- prefer uploading local media over using URLs when sending to WhatsApp
- document that `/send-media` URLs are for UI display only
- add tests covering ogg uploads and WhatsApp media handling

## Testing
- `pytest tests/test_send_media.py::test_upload_sync_sets_audio_ogg tests/test_send_media.py::test_send_to_whatsapp_prefers_upload -q`
- `pytest -q` *(fails: async def functions are not natively supported; missing pytest-asyncio)*

------
https://chatgpt.com/codex/tasks/task_e_68af1567cec48321bf7078ec4f633730