### PR TITLE
Sanitize MIME types before uploading media to GCS

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1222,9 +1222,12 @@ class MessageProcessor:
         """
         try:
             media_content, mime_type = await self.whatsapp_messenger.download_media(media_id)
+            mime_type = mime_type.split(';', 1)[0].strip()
 
             timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
             file_extension = mimetypes.guess_extension(mime_type) or ""
+            if not file_extension and mime_type.startswith("audio/"):
+                file_extension = ".ogg"
             filename = f"{media_type}_{timestamp}_{media_id[:8]}{file_extension}"
             file_path = self.media_dir / filename
 


### PR DESCRIPTION
## Summary
- Sanitize and normalize MIME types before generating filenames
- Default to `.ogg` for unknown audio types
- Use sanitized MIME type when uploading files to GCS

## Testing
- ⚠️ `pip install -r backend/requirements.txt -r requirements-test.txt` (missing pytest-asyncio)
- ⚠️ `pytest` (async plugin missing)


------
https://chatgpt.com/codex/tasks/task_e_68af1e4724888321be07a16b42e12684