### PR TITLE
fix: rewrite /app media paths in frontend

### DIFF
--- a/frontend/src/MessageBubble.js
+++ b/frontend/src/MessageBubble.js
@@ -12,9 +12,12 @@ const ICONS = {
 };
 
 // Enhanced media URL utility with better error handling
-function getSafeMediaUrl(raw) {
+export function getSafeMediaUrl(raw) {
   if (!raw) return "";
   if (/^https?:\/\//i.test(raw)) return raw;
+  if (raw.startsWith("/app/")) {
+    raw = raw.replace(/^\/app\/(media\/)?/, "/media/");
+  }
   const base = process.env.REACT_APP_API_BASE || "";
   return `${base.replace(/\/$/, "")}/${raw.replace(/^\/+/, "")}`;
 }

--- a/frontend/src/MessageBubble.test.js
+++ b/frontend/src/MessageBubble.test.js
@@ -1,0 +1,9 @@
+jest.mock('wavesurfer.js', () => ({}));
+
+const { getSafeMediaUrl } = require('./MessageBubble');
+
+describe('getSafeMediaUrl', () => {
+  it('rewrites /app/ paths to /media/', () => {
+    expect(getSafeMediaUrl('/app/media/foo.ogg')).toBe('/media/foo.ogg');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure MessageBubble rewrites /app/ media URLs to /media/
- add unit test for getSafeMediaUrl

## Testing
- `npm test -- --watchAll=false`
- `pytest` *(fails: async plugin missing, 9 failed, 20 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68af223fca4c8321b79fde219ad5de78