### PR TITLE
Use relative media paths for served files

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1237,7 +1237,8 @@ class MessageProcessor:
             if not drive_url:
                 raise RuntimeError("GCS upload failed")
 
-            return str(file_path), drive_url
+            # Return a relative path for clients and the public GCS URL
+            return f"/media/{filename}", drive_url
 
         except Exception as e:
             print(f"Error downloading media {media_id}: {e}")
@@ -1691,9 +1692,11 @@ async def send_media(
             # ---------- upload to Google Drive ----------
             media_url = await upload_file_to_gcs(str(file_path))
 
+            # Build a message payload that uses a relative URL for the client
+            relative_path = f"/media/{filename}"
             message_data = {
                 "user_id": user_id,
-                "message": str(file_path),
+                "message": relative_path,
                 # URL is kept for UI display; WhatsApp will use the uploaded media ID
                 "url": media_url,
                 "type": media_type,
@@ -1701,6 +1704,7 @@ async def send_media(
                 "caption": caption,
                 "price": price,
                 "timestamp": datetime.utcnow().isoformat(),
+                # Keep absolute path for internal processing/sending to WhatsApp
                 "media_path": str(file_path),
             }
 

--- a/frontend/src/MessageBubble.test.js
+++ b/frontend/src/MessageBubble.test.js
@@ -6,4 +6,9 @@ describe('getSafeMediaUrl', () => {
   it('rewrites /app/ paths to /media/', () => {
     expect(getSafeMediaUrl('/app/media/foo.ogg')).toBe('/media/foo.ogg');
   });
+
+  it('prefixes relative paths with the API base URL', () => {
+    process.env.REACT_APP_API_BASE = 'https://api.example.com';
+    expect(getSafeMediaUrl('/media/foo.ogg')).toBe('https://api.example.com/media/foo.ogg');
+  });
 });


### PR DESCRIPTION
## Summary
- Serve media via `/media/<filename>` paths instead of absolute filesystem paths
- Return relative media URLs when downloading WhatsApp media
- Add tests covering relative paths and frontend URL joining

## Testing
- `pytest` *(fails: async def functions are not natively supported; missing pytest-asyncio)*
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af314cbb748321b75fb1ede8c54909