### PR TITLE
Handle missing audio URLs gracefully

### DIFF
--- a/frontend/src/MessageBubble.test.js
+++ b/frontend/src/MessageBubble.test.js
@@ -1,5 +1,9 @@
 jest.mock('wavesurfer.js', () => ({}));
+require('@testing-library/jest-dom');
 
+const React = require('react');
+const { render, screen } = require('@testing-library/react');
+const MessageBubble = require('./MessageBubble').default;
 const { getSafeMediaUrl } = require('./MessageBubble');
 
 describe('getSafeMediaUrl', () => {
@@ -10,5 +14,12 @@ describe('getSafeMediaUrl', () => {
   it('prefixes relative paths with the API base URL', () => {
     process.env.REACT_APP_API_BASE = 'https://api.example.com';
     expect(getSafeMediaUrl('/media/foo.ogg')).toBe('https://api.example.com/media/foo.ogg');
+  });
+});
+
+describe('MessageBubble audio handling', () => {
+  it('shows error when audio url is missing', async () => {
+    render(<MessageBubble msg={{ type: 'audio' }} self={false} />);
+    expect(await screen.findByText(/Audio URL missing/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- ensure audio messages only load from `msg.url`
- show clear errors and a download link when audio cannot load
- test audio rendering with missing URL

## Testing
- `npm test -- src/MessageBubble.test.js --watchAll=false`
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68af51c187dc8321a4cdfdef7100cd40