### PR TITLE
Add integration tests for message pagination

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+import asyncio
+import pytest
+from backend import main
+from .utils import bulk_insert_messages
+
+
+@pytest.fixture
+def db_manager(tmp_path, monkeypatch):
+    db_path = tmp_path / "db.sqlite"
+    dm = main.DatabaseManager(str(db_path))
+    asyncio.run(dm.init_db())
+    main.db_manager = dm
+    main.message_processor.db_manager = dm
+    return dm
+
+
+@pytest.fixture
+def client():
+    from fastapi.testclient import TestClient
+    with TestClient(main.app) as c:
+        yield c
+
+
+@pytest.fixture
+def insert_messages():
+    def _insert(dm, user_id: str, count: int, start_index: int = 1):
+        asyncio.run(bulk_insert_messages(dm, user_id, count, start_index))
+    return _insert

--- a/tests/test_message_pagination.py
+++ b/tests/test_message_pagination.py
@@ -1,0 +1,61 @@
+from backend import main
+
+
+def test_second_page_pagination(db_manager, client, insert_messages):
+    # Insert 120 messages and fetch the second page (messages 21-70)
+    insert_messages(db_manager, "user1", 120)
+
+    res = client.get("/messages/user1?offset=50&limit=50")
+    assert res.status_code == 200
+    data = res.json()
+    assert len(data) == 50
+
+    # Ensure chronological order
+    timestamps = [m["timestamp"] for m in data]
+    assert timestamps == sorted(timestamps)
+
+    expected_messages = [f"msg {i}" for i in range(21, 71)]
+    assert [m["message"] for m in data] == expected_messages
+
+
+def test_new_message_persisted_and_paginated(db_manager, client, insert_messages, monkeypatch):
+    # Insert initial 100 messages
+    insert_messages(db_manager, "user1", 100)
+
+    # Stub message processing to immediately store message
+    async def fake_process(message_data):
+        await db_manager.upsert_message({
+            "wa_message_id": "wa_101",
+            "user_id": message_data["user_id"],
+            "message": message_data["message"],
+            "type": message_data.get("type", "text"),
+            "from_me": 1,
+            "status": "sent",
+            "timestamp": message_data["timestamp"],
+        })
+        return {**message_data, "wa_message_id": "wa_101"}
+
+    async def fake_get_recent_messages(*args, **kwargs):
+        return []
+
+    monkeypatch.setattr(main.message_processor, "process_outgoing_message", fake_process)
+    monkeypatch.setattr(main.redis_manager, "get_recent_messages", fake_get_recent_messages)
+
+    # Send a new message
+    resp = client.post("/send-message", json={"user_id": "user1", "message": "msg 101"})
+    assert resp.status_code == 200
+
+    # Fetch first page - should include the new message as the most recent
+    res1 = client.get("/messages/user1?offset=0&limit=50")
+    assert res1.status_code == 200
+    data1 = res1.json()
+    assert len(data1) == 50
+    expected_first_page = [f"msg {i}" for i in range(52, 102)]
+    assert [m["message"] for m in data1] == expected_first_page
+
+    # Fetch second page - should reflect shifted window
+    res2 = client.get("/messages/user1?offset=50&limit=50")
+    assert res2.status_code == 200
+    data2 = res2.json()
+    expected_second_page = [f"msg {i}" for i in range(2, 52)]
+    assert [m["message"] for m in data2] == expected_second_page

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,21 @@
+from datetime import datetime, timedelta
+
+async def bulk_insert_messages(dm, user_id: str, count: int, start_index: int = 1) -> None:
+    """Insert `count` messages for `user_id` with sequential timestamps.
+
+    Each message will have a `wa_message_id` of the form ``wa_<n>`` and a
+    `message` body ``msg <n>`` where ``n`` starts at ``start_index``.
+    ``timestamp`` values begin at 2000-01-01 and increment by one second per
+    message to ensure chronological ordering.
+    """
+    base_time = datetime(2000, 1, 1)
+    for i in range(count):
+        idx = start_index + i
+        await dm.upsert_message({
+            "wa_message_id": f"wa_{idx}",
+            "user_id": user_id,
+            "message": f"msg {idx}",
+            "from_me": 0,
+            "status": "received",
+            "timestamp": (base_time + timedelta(seconds=idx)).isoformat(),
+        })


### PR DESCRIPTION
## Summary
- add `bulk_insert_messages` helper and test fixtures
- test `/messages/{user_id}` pagination with bulk data
- verify new messages persist across paginated fetches

## Testing
- `pytest tests/test_message_pagination.py -q`
- `pytest -q` *(fails: async def functions are not natively supported; missing pytest-asyncio)*

------
https://chatgpt.com/codex/tasks/task_e_68af6d7cdd648321adb45cff1123851b