### PR TITLE
feat: virtualize message list for smoother scrolling

### DIFF
--- a/frontend/src/ChatWindow.js
+++ b/frontend/src/ChatWindow.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useRef, useCallback } from 'react';
+import { VariableSizeList as VirtualList } from 'react-window';
 import api from './api';
 import MessageBubble from './MessageBubble';
 import ForwardDialog from './ForwardDialog';
@@ -156,6 +157,19 @@ export default function ChatWindow({ activeUser, ws, currentAgent, adminWs, onUp
   const fileInputRef = useRef();
   const inputRef = useRef();
   const messagesEndRef = useRef(null);
+  const listRef = useRef(null);
+  const containerRef = useRef(null);
+  const [listHeight, setListHeight] = useState(0);
+  const sizeMap = useRef({});
+  const setSize = (index, size) => {
+    if (sizeMap.current[index] !== size) {
+      sizeMap.current[index] = size;
+      if (listRef.current) {
+        listRef.current.resetAfterIndex(index);
+      }
+    }
+  };
+  const getSize = index => sizeMap.current[index] || 80;
   const canvasRef = useRef();
 
   // Insert date separators like WhatsApp Business
@@ -184,6 +198,16 @@ export default function ChatWindow({ activeUser, ws, currentAgent, adminWs, onUp
   };
 
   const groupedMessages = withDateSeparators(groupConsecutiveImages(messages));
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const update = () => setListHeight(el.clientHeight);
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
 
   // Helpers for current user's pendingImages queue state
   const getUserId = () => activeUser?.user_id || "";
@@ -626,19 +650,16 @@ export default function ChatWindow({ activeUser, ws, currentAgent, adminWs, onUp
   const [preserveScroll, setPreserveScroll] = useState(false);
 
   const scrollToBottom = () => {
-    if (messagesEndRef.current) {
-      messagesEndRef.current.scrollTop = messagesEndRef.current.scrollHeight;
+    if (listRef.current) {
+      listRef.current.scrollToItem(groupedMessages.length - 1, 'end');
     }
   };
 
   const scrollToHit = (hitListIndex) => {
     if (hitListIndex < 0 || hitListIndex >= searchHitIndexes.length) return;
-    const container = messagesEndRef.current;
-    if (!container) return;
     const childIndex = searchHitIndexes[hitListIndex];
-    const child = container.children[childIndex];
-    if (child) {
-      child.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    if (listRef.current) {
+      listRef.current.scrollToItem(childIndex, 'center');
     }
   };
 
@@ -900,6 +921,113 @@ export default function ChatWindow({ activeUser, ws, currentAgent, adminWs, onUp
 
   const pendingImages = getPendingImages();
 
+  const Inner = React.forwardRef(({ style, children }, ref) => (
+    <div ref={ref} style={style} className="p-4">
+      {children}
+    </div>
+  ));
+
+  const Row = ({ index, style }) => {
+    const msg = groupedMessages[index];
+    const rowRef = useRef(null);
+
+    useEffect(() => {
+      if (rowRef.current) {
+        const h = rowRef.current.getBoundingClientRect().height;
+        setSize(index, h);
+      }
+    }, [msg, index]);
+
+    if (msg.__separator) {
+      return (
+        <div style={style} ref={rowRef}>
+          <div className="sticky top-2 z-10 flex justify-center my-2">
+            <span className="px-3 py-1 text-xs rounded-full bg-gray-700 text-gray-200 border border-gray-600">{msg.label}</span>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div style={style} ref={rowRef}>
+        {index === unreadSeparatorIndex && (
+          <div className="text-center text-xs text-gray-400 my-2">Unread Messages</div>
+        )}
+        <MessageBubble
+          msg={msg}
+          self={(function() {
+            // Default to backend-provided flag
+            if (msg.from_me) return true;
+            // Heuristic for internal DMs: align current agent's messages to the right
+            try {
+              const isDm = typeof activeUser?.user_id === 'string' && activeUser.user_id.startsWith('dm:');
+              if (!isDm) return false;
+              const agentLower = String(currentAgent || '').toLowerCase();
+              const sender = String(msg.agent || msg.sender || msg.from || msg.name || '').toLowerCase();
+              return agentLower && sender && agentLower === sender;
+            } catch { return false; }
+          })()}
+          catalogProducts={catalogProducts}
+          highlightQuery={searchQuery}
+          quotedMessage={(function(){
+            try {
+              const qid = msg.reply_to;
+              if (!qid) return null;
+              return messages.find(m => (m.wa_message_id && m.wa_message_id === qid) || (m.id && m.id === qid)) || null;
+            } catch { return null; }
+          })()}
+          onReply={(m)=> setReplyTarget(m)}
+          onReact={(m, emoji)=>{
+            try {
+              const targetId = m.wa_message_id || m.id;
+              if (!targetId || !ws || ws.readyState !== WebSocket.OPEN) return;
+              ws.send(JSON.stringify({ type: 'react', target_wa_message_id: targetId, emoji }));
+            } catch {}
+          }}
+          onForward={(forwardMsg)=>{
+            // Build a proper forward payload that preserves media links
+            const originalType = forwardMsg.type || 'text';
+            const isMedia = originalType === 'image' || originalType === 'audio' || originalType === 'video';
+
+            let messageValue = '';
+            let urlValue = '';
+
+            if (isMedia) {
+              // Prefer explicit url provided by backend (e.g., GCS public link)
+              urlValue = (forwardMsg.url && typeof forwardMsg.url === 'string') ? forwardMsg.url : '';
+              if (urlValue) {
+                messageValue = urlValue;
+              } else if (typeof forwardMsg.message === 'string') {
+                // Fallbacks: if message already an absolute URL use as-is; if it is a local path like /media/..., make it absolute
+                const raw = forwardMsg.message;
+                if (/^https?:\\/\\//i.test(raw)) {
+                  messageValue = raw;
+                } else if (/^\/?media\//i.test(raw) || /^\/app\/media\//i.test(raw) || raw.startsWith('/media/')) {
+                  const base = (process.env.REACT_APP_API_BASE || '').replace(/\/$/, '');
+                  messageValue = `${base}${raw.startsWith('/') ? '' : '/'}${raw.replace(/^\/app\//, '')}`;
+                } else {
+                  // As a last resort, keep the raw string (backend may resolve it)
+                  messageValue = raw;
+                }
+              } else {
+                // If no usable media reference, degrade gracefully to a label
+                messageValue = forwardMsg.caption || '[media]';
+              }
+            } else {
+              // Non-media: forward text or a stringified representation
+              messageValue = typeof forwardMsg.message === 'string' ? forwardMsg.message : (forwardMsg.caption || '[message]');
+            }
+
+            const payload = { message: messageValue, type: isMedia ? originalType : (originalType || 'text') };
+            if (isMedia && urlValue) payload.url = urlValue;
+            forwardPayloadRef.current = payload;
+            setForwardOpen(true);
+          }}
+        />
+      </div>
+    );
+  };
+
   return (
     <div
       className="flex flex-col h-full"
@@ -1033,91 +1161,25 @@ export default function ChatWindow({ activeUser, ws, currentAgent, adminWs, onUp
         </div>
       )}
       
-      <div key={activeUser?.user_id || 'no-user'} className="flex-1 overflow-y-auto p-4 space-y-2 bg-gray-900" ref={messagesEndRef}>
-        {groupedMessages.map((msg, index) => (
-          msg.__separator ? (
-            <div key={msg.key} className="sticky top-2 z-10 flex justify-center my-2">
-              <span className="px-3 py-1 text-xs rounded-full bg-gray-700 text-gray-200 border border-gray-600">{msg.label}</span>
-            </div>
-          ) : (
-            <React.Fragment key={msg.id || msg.temp_id || index}>
-              {index === unreadSeparatorIndex && (
-                <div className="text-center text-xs text-gray-400 my-2">Unread Messages</div>
-              )}
-              <MessageBubble
-                msg={msg}
-                self={(function() {
-                  // Default to backend-provided flag
-                  if (msg.from_me) return true;
-                  // Heuristic for internal DMs: align current agent's messages to the right
-                  try {
-                    const isDm = typeof activeUser?.user_id === 'string' && activeUser.user_id.startsWith('dm:');
-                    if (!isDm) return false;
-                    const agentLower = String(currentAgent || '').toLowerCase();
-                    const sender = String(msg.agent || msg.sender || msg.from || msg.name || '').toLowerCase();
-                    return agentLower && sender && agentLower === sender;
-                  } catch { return false; }
-                })()}
-                catalogProducts={catalogProducts}
-                highlightQuery={searchQuery}
-                quotedMessage={(function(){
-                  try {
-                    const qid = msg.reply_to;
-                    if (!qid) return null;
-                    return messages.find(m => (m.wa_message_id && m.wa_message_id === qid) || (m.id && m.id === qid)) || null;
-                  } catch { return null; }
-                })()}
-                onReply={(m)=> setReplyTarget(m)}
-                onReact={(m, emoji)=>{
-                  try {
-                    const targetId = m.wa_message_id || m.id;
-                    if (!targetId || !ws || ws.readyState !== WebSocket.OPEN) return;
-                    ws.send(JSON.stringify({ type: 'react', target_wa_message_id: targetId, emoji }));
-                  } catch {}
-                }}
-                onForward={(forwardMsg)=>{
-                  // Build a proper forward payload that preserves media links
-                  const originalType = forwardMsg.type || 'text';
-                  const isMedia = originalType === 'image' || originalType === 'audio' || originalType === 'video';
-
-                  let messageValue = '';
-                  let urlValue = '';
-
-                  if (isMedia) {
-                    // Prefer explicit url provided by backend (e.g., GCS public link)
-                    urlValue = (forwardMsg.url && typeof forwardMsg.url === 'string') ? forwardMsg.url : '';
-                    if (urlValue) {
-                      messageValue = urlValue;
-                    } else if (typeof forwardMsg.message === 'string') {
-                      // Fallbacks: if message already an absolute URL use as-is; if it is a local path like /media/..., make it absolute
-                      const raw = forwardMsg.message;
-                      if (/^https?:\/\//i.test(raw)) {
-                        messageValue = raw;
-                      } else if (/^\/?media\//i.test(raw) || /^\/app\/media\//i.test(raw) || raw.startsWith('/media/')) {
-                        const base = (process.env.REACT_APP_API_BASE || '').replace(/\/$/, '');
-                        messageValue = `${base}${raw.startsWith('/') ? '' : '/'}${raw.replace(/^\/app\//, '')}`;
-                      } else {
-                        // As a last resort, keep the raw string (backend may resolve it)
-                        messageValue = raw;
-                      }
-                    } else {
-                      // If no usable media reference, degrade gracefully to a label
-                      messageValue = forwardMsg.caption || '[media]';
-                    }
-                  } else {
-                    // Non-media: forward text or a stringified representation
-                    messageValue = typeof forwardMsg.message === 'string' ? forwardMsg.message : (forwardMsg.caption || '[message]');
-                  }
-
-                  const payload = { message: messageValue, type: isMedia ? originalType : (originalType || 'text') };
-                  if (isMedia && urlValue) payload.url = urlValue;
-                  forwardPayloadRef.current = payload;
-                  setForwardOpen(true);
-                }}
-              />
-            </React.Fragment>
-          )
-        ))}
+      <div
+        key={activeUser?.user_id || 'no-user'}
+        className="flex-1 bg-gray-900"
+        ref={containerRef}
+      >
+        {listHeight > 0 && (
+          <VirtualList
+            height={listHeight}
+            width="100%"
+            itemCount={groupedMessages.length}
+            itemSize={getSize}
+            ref={listRef}
+            outerRef={messagesEndRef}
+            innerElementType={Inner}
+            className="overflow-y-auto"
+          >
+            {Row}
+          </VirtualList>
+        )}
       </div>
       
       {activeUser && (


### PR DESCRIPTION
## Summary
- replace groupedMessages.map with `react-window` `VariableSizeList`
- keep unread separators and scroll-to-bottom logic using the virtualized list

## Testing
- `npm test --prefix frontend -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b370c372ec832191abb9283baccf8a