### PR TITLE
chore: trim Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,9 @@ __pycache__
 *.sqlite3
 .venv
 .git
+frontend/node_modules
+frontend/build
+frontend/tests
+backend/__pycache__
+backend/tests
+tests


### PR DESCRIPTION
## Summary
- ignore frontend build and node modules in Docker builds
- exclude backend cache and test directories from context

## Testing
- `pytest` *(fails: Directory 'frontend/build' does not exist)*
- `docker build -t whatsapp-last:test .` *(command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68b37cb1c2348321a477b0f59c04739e