### PR TITLE
Handle WaveSurfer abort errors gracefully

### DIFF
--- a/frontend/src/MessageBubble.js
+++ b/frontend/src/MessageBubble.js
@@ -190,8 +190,6 @@ export default function MessageBubble({ msg, self, catalogProducts = {}, highlig
           backend: 'MediaElement',
         });
 
-        setAudioError(false);
-
         wavesurfer.on("ready", () => {
           setAudioError(false);
           try {
@@ -203,6 +201,24 @@ export default function MessageBubble({ msg, self, catalogProducts = {}, highlig
         });
         wavesurfer.on("finish", () => setPlaying(false));
         wavesurfer.on("error", (error) => {
+          const message =
+            typeof error === "string"
+              ? error
+              : error?.message || "";
+          const name =
+            typeof error === "object" && error !== null
+              ? error.name || ""
+              : "";
+          const isAbortError =
+            name === "AbortError" ||
+            /abort(ed|ing)?/i.test(message) ||
+            /destroy(ed|ing)?/i.test(message);
+
+          if (isAbortError) {
+            console.debug("WaveSurfer aborted/destroyed:", error);
+            return;
+          }
+
           console.error("WaveSurfer error:", error);
           setAudioError(true);
         });


### PR DESCRIPTION
## Summary
- avoid clearing audio errors until WaveSurfer reports ready
- ignore expected abort and destroy errors when loading new audio waveforms

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68caa2e07c8c83218a4f6ca8f997c6c2